### PR TITLE
Fixed a bug in PerpendicularSegment

### DIFF
--- a/src/element/composition.js
+++ b/src/element/composition.js
@@ -438,7 +438,7 @@ define([
                 "\nPossible parent types: [line,point]");
         }
         attr = Type.copyAttributes(attributes, board.options, 'perpendicularsegment', 'point');
-        t = JXG.createPerpendicularPoint(board, [l, p], attr);
+        t = JXG.createOrthogonalProjection(board, [l, p], attr);
 
         t.dump = false;
 


### PR DESCRIPTION
Replaced a usage of the buggy PerpendicularPoint in PerpendicularSegment. PerpendicularPoint doesn't work when the point falls on the line.
